### PR TITLE
add common proxy headers to default headers

### DIFF
--- a/osprey-method-handler.js
+++ b/osprey-method-handler.js
@@ -24,6 +24,10 @@ require('standard-headers').forEach(function (header) {
   DEFAULT_HEADER_PARAMS[header] = { type: 'string' };
 });
 
+['x-forwarded-for', 'x-forwarded-host', 'x-forwarded-proto'].forEach(function (header) {
+  DEFAULT_HEADER_PARAMS[header] = { type: 'string' };
+});
+
 /**
  * Application body parsers and validators.
  *


### PR DESCRIPTION
These headers are quite common in a setup which involves reverse proxying. I suggest to include them in the default header params, so they don't have to be explicitly specified in the RAML descriptor.