### PR TITLE
Include `params` property when mapping ajv errors

### DIFF
--- a/osprey-method-handler.js
+++ b/osprey-method-handler.js
@@ -723,7 +723,8 @@ function formatRamlErrors (errors, type) {
       keyword: error.rule,
       schema: error.attr,
       data: error.value,
-      message: 'invalid ' + type + ' (' + error.rule + ', ' + error.attr + ')'
+      message: 'invalid ' + type + ' (' + error.rule + ', ' + error.attr + ')',
+      params: error.params
     }
   })
 }


### PR DESCRIPTION
Currently some error messages for types like "required" fail to show the property name in node-request-error-handler because `dataPath` is not provided by ajv anymore for errors like missing properties.

From the [ajv docs](https://www.npmjs.com/package/ajv#error-objects) regarding the validation `error` object:
>
params: the object with the additional information about error that can be used to create custom error messages (e.g., using ajv-i18n package). See below for parameters set by all keywords.


More info related the empty `dataPath` property [here](https://github.com/epoberezkin/ajv/issues/93).