### PR TITLE
Allow other types than only objects as root type in RAML 1.0

### DIFF
--- a/osprey-method-handler.js
+++ b/osprey-method-handler.js
@@ -344,6 +344,11 @@ function jsonBodyHandler (body, path, method, options) {
   })
   var middleware = [jsonBodyParser]
   var schema = body && (body.properties || body.type || body.schema) || undefined
+
+  if (Array.isArray(schema)) {
+    schema = body
+  }
+
   var isRAMLType = schema.constructor === {}.constructor
 
   if (schema) {

--- a/osprey-method-handler.js
+++ b/osprey-method-handler.js
@@ -343,9 +343,12 @@ function jsonBodyHandler (body, path, method, options) {
     reviver: options.reviver
   })
   var middleware = [jsonBodyParser]
-  var schema = body && (body.properties || body.type || body.schema) || undefined
 
-  if (Array.isArray(schema)) {
+  var schema = body && (body.properties || body.type) || undefined
+
+  if (!schema) {
+    schema = body.schema
+  } else if (Array.isArray(schema)) {
     schema = body
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -608,7 +608,7 @@ describe('osprey method handler', function () {
               items: 'string'
             }
           }
-        }, '/', 'POST'), function (req, res) {
+        }, '/', 'POST', { RAMLVersion: 'RAML10' }), function (req, res) {
           expect(req.body).to.deep.equal([ 'a', 'b', 'c' ])
         })
 
@@ -636,7 +636,7 @@ describe('osprey method handler', function () {
               items: 'string'
             }
           }
-        }, '/', 'POST'), function (req, res) {
+        }, '/', 'POST', { RAMLVersion: 'RAML10' }), function (req, res) {
           res.end('failure')
         })
 
@@ -665,7 +665,7 @@ describe('osprey method handler', function () {
               type: [ 'string' ]
             }
           }
-        }, '/', 'POST'), function (req, res) {
+        }, '/', 'POST', { RAMLVersion: 'RAML10' }), function (req, res) {
           expect(req.body).to.equal('test')
         })
 
@@ -692,7 +692,7 @@ describe('osprey method handler', function () {
               type: [ 'integer' ]
             }
           }
-        }, '/', 'POST'), function (req, res) {
+        }, '/', 'POST', { RAMLVersion: 'RAML10' }), function (req, res) {
           res.send('failure')
         })
 
@@ -1096,6 +1096,7 @@ describe('osprey method handler', function () {
         }, '/', 'POST', { RAMLVersion: 'RAML10' }))
 
         app.use(function (err, req, res, next) {
+          console.log(require('util').inspect(err, false, null))
           expect(err.ramlValidation).to.be.true
           expect(err.requestErrors).to.deep.equal([
             {

--- a/test/index.js
+++ b/test/index.js
@@ -1100,7 +1100,6 @@ describe('osprey method handler', function () {
         }, '/', 'POST', { RAMLVersion: 'RAML10' }))
 
         app.use(function (err, req, res, next) {
-          console.log(require('util').inspect(err, false, null))
           expect(err.ramlValidation).to.be.true
           expect(err.requestErrors).to.deep.equal([
             {

--- a/test/index.js
+++ b/test/index.js
@@ -597,6 +597,120 @@ describe('osprey method handler', function () {
             expect(res.status).to.equal(200)
           })
       })
+
+      it('should accept arrays as root elements', function () {
+        var app = router()
+
+        app.post('/', handler({
+          body: {
+            'application/json': {
+              type: [ 'array' ],
+              items: 'string'
+            }
+          }
+        }, '/', 'POST'), function (req, res) {
+          expect(req.body).to.deep.equal([ 'a', 'b', 'c' ])
+        })
+
+        return popsicle.default({
+          url: '/',
+          method: 'post',
+          headers: {
+            'Content-Type': 'application/json; charset=utf-8'
+          },
+          body: [ 'a', 'b', 'c' ]
+        })
+          .use(server(createServer(app)))
+          .then(function (res) {
+            expect(res.body).to.equal('success')
+            expect(res.status).to.equal(200)
+          })
+      })
+      it('should reject objects when an array is set as root element', function () {
+        var app = router()
+
+        app.post('/', handler({
+          body: {
+            'application/json': {
+              type: [ 'array' ],
+              items: 'string'
+            }
+          }
+        }, '/', 'POST'), function (req, res) {
+          res.end('failure')
+        })
+
+        return popsicle.default({
+          url: '/',
+          method: 'post',
+          headers: {
+            'Content-Type': 'application/json; charset=utf-8'
+          },
+          body: {
+            foo: 'bar'
+          }
+        })
+          .use(server(createServer(app)))
+          .then(function (res) {
+            expect(res.status).to.equal(400)
+          })
+      })
+
+      it('should accept strings as root elements', function () {
+        var app = router()
+
+        app.post('/', handler({
+          body: {
+            'application/json': {
+              type: [ 'string' ]
+            }
+          }
+        }, '/', 'POST'), function (req, res) {
+          expect(req.body).to.equal('test')
+        })
+
+        return popsicle.default({
+          url: '/',
+          method: 'post',
+          headers: {
+            'Content-Type': 'application/json; charset=utf-8'
+          },
+          body: 'test'
+        })
+          .use(server(createServer(app)))
+          .then(function (res) {
+            expect(res.body).to.equal('success')
+            expect(res.status).to.equal(200)
+          })
+      })
+      it('should reject objects when a string is set as root element', function () {
+        var app = router()
+
+        app.post('/', handler({
+          body: {
+            'application/json': {
+              type: [ 'integer' ]
+            }
+          }
+        }, '/', 'POST'), function (req, res) {
+          res.send('failure')
+        })
+
+        return popsicle.default({
+          url: '/',
+          method: 'post',
+          headers: {
+            'Content-Type': 'application/json; charset=utf-8'
+          },
+          body: {
+            foo: 'bar'
+          }
+        })
+          .use(server(createServer(app)))
+          .then(function (res) {
+            expect(res.status).to.equal(400)
+          })
+      })
     })
 
     describe('json', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -610,6 +610,8 @@ describe('osprey method handler', function () {
           }
         }, '/', 'POST', { RAMLVersion: 'RAML10' }), function (req, res) {
           expect(req.body).to.deep.equal([ 'a', 'b', 'c' ])
+
+          res.end('success')
         })
 
         return popsicle.default({
@@ -667,6 +669,8 @@ describe('osprey method handler', function () {
           }
         }, '/', 'POST', { RAMLVersion: 'RAML10' }), function (req, res) {
           expect(req.body).to.equal('test')
+
+          res.end('success')
         })
 
         return popsicle.default({
@@ -675,7 +679,7 @@ describe('osprey method handler', function () {
           headers: {
             'Content-Type': 'application/json; charset=utf-8'
           },
-          body: 'test'
+          body: '"test"'
         })
           .use(server(createServer(app)))
           .then(function (res) {


### PR DESCRIPTION
Depends on mulesoft-labs/node-raml-validate#6

Allows for elements other than objets at the root of JSON requests.

---

Currently, `osprey-method-handler` only accepts resources that use object types in their body. However, all RAML types should be valid for request and response bodies, including `array`, `string`, `integer`, ... (Granted, using strings or integers as root elements in request or response-bodies isn't a nice thing to do, but arrays should be perfectly valid and if you must, even a single number is valid JSON.)

**Example:**
Using the following specification in Osprey yields an error in `osprey-method-handler`.
```raml
#%RAML 1.0
title: Test API

/test:
  post:
    body:
      application/json:
        type: array
        items: string
```

```
SyntaxError: Unable to compile JSON schema for post /test: Unexpected token a in JSON at position 0
    at JSON.parse (<anonymous>)
    at jsonBodyValidationHandler (/[...]/osprey-method-handler/osprey-method-handler.js:429:21)
    at jsonBodyHandler (/[...]/osprey-method-handler/osprey-method-handler.js:350:21)
    at /[...]/osprey-method-handler/osprey-method-handler.js:295:29
    at Array.forEach (native)
    at /[...]/osprey-method-handler/osprey-method-handler.js:291:14
    at Array.forEach (native)
    at bodyHandler (/[...]/osprey-method-handler/osprey-method-handler.js:279:9)
    at ospreyMethodHandler (/[...]/osprey-method-handler/osprey-method-handler.js:105:21)
    at /[...]/osprey/lib/server.js:39:12
```

(This PR also includes #24)