### PR TITLE
Use an optional user-provided ajv instance for JSON schema validation.

### DIFF
--- a/osprey-method-handler.js
+++ b/osprey-method-handler.js
@@ -79,8 +79,13 @@ module.exports.addJsonSchema = addJsonSchema
  * @param {Object} schema
  * @param {String} key
  */
-function addJsonSchema (schema, key) {
-  ajv.addSchema(schema, key)
+function addJsonSchema (schema, key, options) {
+  options = options || {}
+  if (options.ajv) {
+    options.ajv.addSchema(schema, key)
+  } else {
+    ajv.addSchema(schema, key)
+  }
 }
 
 /**
@@ -451,12 +456,12 @@ function jsonBodyValidationHandler (schema, path, method, options) {
       schema = JSON.parse(schema)
 
       // Convert draft-03 schema to 04.
-      if (JSON_SCHEMA_03.test(schema.$schema)) {
+      if (!options.ajv && JSON_SCHEMA_03.test(schema.$schema)) {
         schema = jsonSchemaCompatibility.v4(schema)
         schema.$schema = 'http://json-schema.org/draft-04/schema'
       }
 
-      validate = ajv.compile(schema)
+      validate = options.ajv ? options.ajv.compile(schema) : ajv.compile(schema)
     } catch (err) {
       err.message = 'Unable to compile JSON schema for ' + method + ' ' + path + ': ' + err.message
       throw err

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,35 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sinonjs/commons": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
+      "integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.1.0.tgz",
+      "integrity": "sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/samsam": "^2 || ^3"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.1.0.tgz",
+      "integrity": "sha512-IXio+GWY+Q8XUjHUOgK7wx8fpvr7IFffgyXb1bnJFfX3001KmHt35Zq4tp7MXZyjJPCLPuadesDYNk41LYtVjw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.0.2",
+        "array-from": "^2.1.1",
+        "lodash.get": "^4.4.2"
+      }
+    },
     "@types/concat-stream": {
       "version": "1.6.0",
       "resolved": "http://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz",
@@ -123,6 +152,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
       "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ=="
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+      "dev": true
     },
     "array-includes": {
       "version": "3.0.3",
@@ -1527,6 +1562,12 @@
         "array-includes": "^3.0.3"
       }
     },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -1576,14 +1617,19 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "optional": true
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "optional": true
+    },
+    "lolex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-3.0.0.tgz",
+      "integrity": "sha512-hcnW80h3j2lbUfFdMArd5UPA/vxZJ+G8vobd+wg3nVEQA0EigStbYcrG030FJxL6xiDDPEkoMatV9xIh5OecQQ==",
+      "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -1784,6 +1830,36 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "nise": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.8.tgz",
+      "integrity": "sha512-kGASVhuL4tlAV0tvA34yJYZIVihrUt/5bDwpp4tTluigxUr2bBlJeDXmivb6NuEdFkqvdv/Ybb9dm16PSKUhtw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "^3.1.0",
+        "just-extend": "^4.0.2",
+        "lolex": "^2.3.2",
+        "path-to-regexp": "^1.7.0",
+        "text-encoding": "^0.6.4"
+      },
+      "dependencies": {
+        "lolex": {
+          "version": "2.7.5",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+          "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
+    },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
@@ -1901,7 +1977,7 @@
         "array-flatten": "^2.0.0",
         "methods": "^1.1.1",
         "raml-path-match": "^2.2.0",
-        "router": "github:blakeembrey/router#5eb68560e91b302251ff17a70cd1b6af1fc36d30",
+        "router": "github:blakeembrey/router#router-engine",
         "xtend": "^4.0.1"
       }
     },
@@ -2520,6 +2596,38 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
+    "sinon": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.2.3.tgz",
+      "integrity": "sha512-i6j7sqcLEqTYqUcMV327waI745VASvYuSuQMCjbAwlpAeuCgKZ3LtrjDxAbu+GjNQR0FEDpywtwGCIh8GicNyg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.3.0",
+        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/samsam": "^3.0.2",
+        "diff": "^3.5.0",
+        "lolex": "^3.0.0",
+        "nise": "^1.4.8",
+        "supports-color": "^5.5.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "slice-ansi": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
@@ -2719,6 +2827,12 @@
         "slice-ansi": "1.0.0",
         "string-width": "^2.1.1"
       }
+    },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
     },
     "text-table": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "popsicle": "^10.0.0",
     "popsicle-server": "^2.0.0",
     "pre-commit": "^1.0.5",
+    "sinon": "^7.2.3",
     "standard": "^12.0.0"
   },
   "dependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -2,6 +2,7 @@
 /* eslint-disable no-unused-expressions */
 
 var expect = require('chai').expect
+var sinon = require('sinon')
 var popsicle = require('popsicle')
 var server = require('popsicle-server')
 var router = require('osprey-router')
@@ -9,6 +10,7 @@ var finalhandler = require('finalhandler')
 var fs = require('fs')
 var join = require('path').join
 var streamEqual = require('stream-equal')
+const Ajv = require('ajv')
 var handler = require('../')
 
 describe('osprey method handler', function () {
@@ -905,6 +907,60 @@ describe('osprey method handler', function () {
           })
       })
 
+      it('should use a custom ajv instance for validation if provided in options', function () {
+        var ajv = Ajv({
+          schemaId: 'auto',
+          allErrors: true,
+          verbose: true,
+          jsonPointers: true,
+          errorDataPath: 'property'
+        })
+        // ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-07.json'))
+        // ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-03.json'))
+
+        var compile = sinon.spy(ajv, 'compile')
+
+        var schema = {
+          $schema: 'http://json-schema.org/draft-07/schema',
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string'
+            }
+          },
+          required: [
+            'name'
+          ]
+        }
+        var app = router()
+
+        app.post('/', handler({
+          body: {
+            'application/json': {
+              schema: JSON.stringify(schema)
+            }
+          }
+        },
+        null,
+        null,
+        { ajv }
+        ))
+
+        return popsicle.default({
+          url: '/',
+          method: 'post',
+          body: '{"url":"http://example.com"}',
+          headers: {
+            'Content-Type': 'application/json'
+          }
+        })
+          .use(server(createServer(app)))
+          .then(function (res) {
+            expect(res.status).to.equal(400)
+            sinon.assert.calledWith(compile, schema)
+          })
+      })
+
       it('should support external $ref when added', function () {
         var schema = JSON.stringify({
           $schema: 'http://json-schema.org/draft-04/schema#',
@@ -987,6 +1043,106 @@ describe('osprey method handler', function () {
           .use(server(createServer(app)))
           .then(function (res) {
             expect(res.status).to.equal(200)
+          })
+      })
+
+      it('should support external $ref with a custom ajv instance', function () {
+        var ajv = Ajv({
+          schemaId: 'auto',
+          allErrors: true,
+          verbose: true,
+          jsonPointers: true,
+          errorDataPath: 'property'
+        })
+        // ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-07.json'))
+        ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'))
+
+        var addSchema = sinon.spy(ajv, 'addSchema')
+
+        var schema = JSON.stringify({
+          $schema: 'http://json-schema.org/draft-04/schema#',
+          title: 'Product set',
+          type: 'array',
+          items: {
+            title: 'Product',
+            type: 'object',
+            properties: {
+              id: {
+                description: 'The unique identifier for a product',
+                type: 'number'
+              },
+              name: {
+                type: 'string'
+              },
+              price: {
+                type: 'number',
+                minimum: 0,
+                exclusiveMinimum: true
+              },
+              tags: {
+                type: 'array',
+                items: {
+                  type: 'string'
+                },
+                minItems: 1,
+                uniqueItems: true
+              },
+              dimensions: {
+                type: 'object',
+                properties: {
+                  length: { type: 'number' },
+                  width: { type: 'number' },
+                  height: { type: 'number' }
+                },
+                required: ['length', 'width', 'height']
+              },
+              warehouseLocation: {
+                description: 'Coordinates of the warehouse with the product',
+                $ref: 'http://json-schema.org/geo'
+              }
+            },
+            required: ['id', 'name', 'price']
+          }
+        })
+
+        var app = router()
+
+        // Register GeoJSON schema.
+        handler.addJsonSchema(
+          require('./vendor/geo.json'),
+          'http://json-schema.org/geo',
+          { ajv }
+        )
+
+        app.post('/', handler({
+          body: {
+            'application/json': {
+              schema: schema
+            }
+          }
+        }, null, null, { ajv }
+        ), function (req, res) {
+          res.end('success')
+        })
+
+        return popsicle.default({
+          url: '/',
+          method: 'post',
+          body: [{
+            id: 123,
+            name: 'Product',
+            price: 12.34,
+            tags: ['foo', 'bar'],
+            warehouseLocation: {
+              latitude: 123,
+              longitude: 456
+            }
+          }]
+        })
+          .use(server(createServer(app)))
+          .then(function (res) {
+            expect(res.status).to.equal(200)
+            sinon.assert.calledOnce(addSchema)
           })
       })
 


### PR DESCRIPTION
Greetings and thanks for the great work! In my use case I have JSON schemas with lots of custom ajv keywords and formats. I would like to be able to validate these using ospray but I could not figure out how to load the custom formats.

This PR is an attempt to enable the user to pass her own (configured) instance of ajv to the method handler.

Thanks again for your time.